### PR TITLE
Fix lastTestedNVDAVersion for some  add-ons

### DIFF
--- a/data/addonsData.json
+++ b/data/addonsData.json
@@ -702,7 +702,7 @@
 				0
 			],
 			"lastTestedNVDAVersion": [
-				2021,
+				2020,
 				3,
 				0
 			]

--- a/data/addonsData.json
+++ b/data/addonsData.json
@@ -71,8 +71,8 @@
 				0
 			],
 			"lastTestedNVDAVersion": [
-				2021,
-				3,
+				2020,
+				2,
 				0
 			]
 		},

--- a/data/addonsData.json
+++ b/data/addonsData.json
@@ -552,7 +552,7 @@
 				0
 			],
 			"lastTestedNVDAVersion": [
-				2021,
+				2019,
 				3,
 				0
 			]

--- a/data/addonsData.json
+++ b/data/addonsData.json
@@ -988,7 +988,7 @@
 				0
 			],
 			"lastTestedNVDAVersion": [
-				2021,
+				2019,
 				3,
 				0
 			]

--- a/data/addonsData.json
+++ b/data/addonsData.json
@@ -657,7 +657,7 @@
 				0
 			],
 			"lastTestedNVDAVersion": [
-				2021,
+				2019,
 				3,
 				1
 			]


### PR DESCRIPTION
When looking at the structure of addonsData.json I've noticed that for some add-ons lastTestedNVDAVersion is set to a value different to what their manifest states. This PR fixes cases which I've noticed but I haven't done an exhaustive review so it is more than likely there are cases I've missed. BTW: Enhanced Aria  is defined twice - both in the active and in the legacy section.