### PR TITLE
Update last compatible version for Synth ring settings selector

### DIFF
--- a/data/addonsData.json
+++ b/data/addonsData.json
@@ -1076,9 +1076,9 @@
 				0
 			],
 			"lastTestedNVDAVersion": [
-				2019,
+				2021,
 				3,
-				0
+				1
 			]
 		},
 		"systrayList": {


### PR DESCRIPTION
This add-on is now compatible with 2021.3.1, but the update is not proposed via add-on updater.
Cc @josephsl 